### PR TITLE
Avoid crash when an schema does not have "properties" key

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "jest",
     "lint": "tslint --project ."
   },
-  "dependencies": {},
   "devDependencies": {
     "@types/jest": "^26.0.0",
     "@types/lodash": "^4.14.161",

--- a/src/transforms/transformObject.ts
+++ b/src/transforms/transformObject.ts
@@ -6,7 +6,7 @@ export function transformObject(
   prop: any,
   generator: ZapierSchemaGenerator
 ): Partial<FieldSchema> | null {
-  const children = (Object.entries(prop.properties).map(([key, value]) =>
+  const children = (Object.entries(prop.properties || {}).map(([key, value]) =>
     generator.getFieldSchema(value, key, fieldSchema.key)
   ) as unknown) as FieldSchema[];
   return {


### PR DESCRIPTION
If a schema node does not have a `properties` key the library crashes. There are json schemas that may have not a `properties` key because the property itself is an object which may have the `additionalProperties` key instead of the `properties` one.